### PR TITLE
Fixes build errors on case sensitive filesystems

### DIFF
--- a/Repetier-Server/Poco/CMakeLists.txt
+++ b/Repetier-Server/Poco/CMakeLists.txt
@@ -19,6 +19,6 @@ if(WIN32)
 ENDIF()
 
 add_subdirectory("Foundation")
-add_subdirectory("NET")
+add_subdirectory("Net")
 add_subdirectory("Util")
 add_subdirectory("XML")

--- a/Repetier-Server/Poco/Foundation/CMakeLists.txt
+++ b/Repetier-Server/Poco/Foundation/CMakeLists.txt
@@ -29,7 +29,7 @@ SET(FOUNDATION_SOURCES ${FOUNDATION_SOURCES}
     src/ArchiveStrategy.cpp
     src/Ascii.cpp
     src/ASCIIEncoding.cpp
-    src/AsyncCHannel.cpp
+    src/AsyncChannel.cpp
     src/AtomicCounter.cpp
     src/Base64Decoder.cpp
     src/Base64Encoder.cpp
@@ -94,7 +94,7 @@ SET(FOUNDATION_SOURCES ${FOUNDATION_SOURCES}
     src/NamedMutex.cpp
     src/NestedDiagnosticContext.cpp
     src/Notification.cpp
-    src/Notificationcenter.cpp
+    src/NotificationCenter.cpp
     src/NotificationQueue.cpp
     src/NullChannel.cpp
     src/NullStream.cpp


### PR DESCRIPTION
Looks like there were some case typos in some CMakeLists.txt files that cause build errors on case sensitive file systems.

With this fix, I was able to build development on a raspberry pi directly ( raspbian wheezy ) .
